### PR TITLE
Fix Fortran docs bug

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.abspath('.'))
 # -- Project information -----------------------------------------------------
 
 project = 'SmartSim'
-copyright = '2020, Cray, a Hewlett Packard Enterprise company'
+copyright = '2021, Hewlett Packard Enterprise'
 author = 'HPE AI & Advanced Productivity'
 
 # The full version, including alpha/beta/rc tags
@@ -38,6 +38,8 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
+    'sphinxfortran.fortran_domain',
+    'sphinxfortran.fortran_autodoc',
     'breathe',
     'nbsphinx'
 ]
@@ -56,6 +58,11 @@ breathe_projects = {
         "fortran_client":"../smartredis/doc/fortran_client/xml",
         "cpp_client":"../smartredis/doc/cpp_client/xml"
         }
+
+fortran_src = [
+    "../smartredis/src/fortran/client.F90",
+    "../smartredis/src/fortran/dataset.F90"
+]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ dev =
     pytest==5.0.1
     pytest-cov>=2.10.1
     nbsphinx>=0.8.2
+    sphinx-fortran=1.1.1
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
sphinx-fortran was not building the fortran
docs because the source files were not specified.

They are now listed and the doc branch will be updated.